### PR TITLE
Do not store miniquad Context in nonaquad renderer

### DIFF
--- a/nona/src/lib.rs
+++ b/nona/src/lib.rs
@@ -4,17 +4,17 @@ extern crate bitflags;
 mod cache;
 mod color;
 mod context;
+mod errors;
 mod fonts;
 mod math;
-mod errors;
 pub mod renderer;
 
 pub use color::*;
 pub use context::{
-    Align, BasicCompositeOperation, BlendFactor, CompositeOperation, Context, Gradient, ImageFlags,
-    ImageId, ImagePattern, LineCap, LineJoin, Paint, Solidity, TextMetrics,
+    Align, BasicCompositeOperation, BlendFactor, Canvas, CompositeOperation, Context, Gradient,
+    ImageFlags, ImageId, ImagePattern, LineCap, LineJoin, Paint, Solidity, TextMetrics,
 };
+pub use errors::*;
 pub use fonts::FontId;
 pub use math::*;
 pub use renderer::Renderer;
-pub use errors::*;

--- a/nona/src/renderer.rs
+++ b/nona/src/renderer.rs
@@ -17,7 +17,7 @@ pub trait Renderer {
     fn edge_antialias(&self) -> bool;
 
     fn view_size(&self) -> (f32, f32);
-    
+
     fn device_pixel_ratio(&self) -> f32;
 
     fn create_texture(

--- a/nonaquad/examples/drawaa.rs
+++ b/nonaquad/examples/drawaa.rs
@@ -4,20 +4,16 @@ use nonaquad::nvgimpl;
 // use nona::widgets::{Widget, Button};
 // use nonaquad::nvgimpl_orig as nvgimpl;
 
-struct Stage<'a> {
-    renderer: Option<nvgimpl::Renderer<'a>>,
-    nona: nona::Context<nvgimpl::Renderer<'a>>,
+struct Stage {
+    renderer: nvgimpl::Renderer,
+    nona: nona::Context,
 }
 
-static mut MINI_CONTEXT: Option<Context> = None;
-fn get_context() -> &'static mut Context {
-    unsafe { MINI_CONTEXT.as_mut().unwrap_or_else(|| panic!()) }
-}
-
-impl<'a> Stage<'a> {
-    pub fn new() -> Stage<'a> {
-        let mut renderer = nvgimpl::Renderer::create(get_context()).unwrap();
-        let mut nona = nona::Context::create(&mut renderer).unwrap();
+impl Stage {
+    pub fn new(ctx: &mut Context) -> Stage {
+        let mut renderer = nvgimpl::Renderer::create(ctx).unwrap();
+        let mut nona =
+            nona::Context::create(&mut nvgimpl::RendererCtx::new(&mut renderer, ctx)).unwrap();
 
         // for demo: load font by embedding into binary
         let font_data: &'static [u8] = include_bytes!("Roboto-Bold.ttf");
@@ -26,105 +22,75 @@ impl<'a> Stage<'a> {
         // use this to load fonts dynamically at runtime:
         // nona.create_font_from_file("roboto", "examples/Roboto-Bold.ttf")
         //     .unwrap();
-        Stage {
-            renderer: Some(renderer),
-            nona,
-        }
+        Stage { renderer, nona }
     }
 }
 
-impl<'a> EventHandlerFree for Stage<'a> {
-    fn update(&mut self) {}
+impl EventHandler for Stage {
+    fn update(&mut self, _ctx: &mut Context) {}
 
-    fn draw(&mut self) {
+    fn draw(&mut self, ctx: &mut Context) {
         // let ctx = get_context();
 
-        let nona = &mut self.nona;
-        nona.attach_renderer(self.renderer.take());
+        self.nona.attach_renderer(
+            &mut nvgimpl::RendererCtx::new(&mut self.renderer, ctx),
+            |canvas| {
+                canvas
+                    .begin_frame(Some(Color::rgb_i(128, 128, 255)))
+                    .unwrap();
 
-        nona.begin_frame(Some(Color::rgb_i(128, 128, 255))).unwrap();
+                // uncomment to draw a lot of circles - more than maximum GPU vertices on openGL ES 2/WebGL
+                // note: performance is currently low, very CPU-bound. Something to fix in the future.
+                // for i in 0..405 {
+                //     canvas.begin_path();
+                //     // canvas.rect((100.0, 100.0, 400.0, 300.0));
+                //     canvas.circle(Point::new(i as f32, 110.), 32.);
+                //     canvas.fill_paint(Paint::from(Color::rgb_i(255, (i as u32 % 256 as u32) as u8, 0)));
+                //     canvas.fill().unwrap();
+                // }
 
-        // uncomment to draw a lot of circles - more than maximum GPU vertices on openGL ES 2/WebGL
-        // note: performance is currently low, very CPU-bound. Something to fix in the future.
-        // for i in 0..405 {
-        //     nona.begin_path();
-        //     // nona.rect((100.0, 100.0, 400.0, 300.0));
-        //     nona.circle(Point::new(i as f32, 110.), 32.);
-        //     nona.fill_paint(Paint::from(Color::rgb_i(255, (i as u32 % 256 as u32) as u8, 0)));
-        //     nona.fill().unwrap();
-        // }
+                canvas.begin_path();
+                // canvas.rect((100.0, 100.0, 400.0, 300.0));
+                canvas.rounded_rect((100.0, 100.0, 400.0, 300.0), 30.0);
+                canvas.fill_paint(Gradient::Linear {
+                    start: (100, 100).into(),
+                    end: (400, 400).into(),
+                    start_color: Color::rgb_i(0xAA, 0x6C, 0x39),
+                    end_color: Color::rgb_i(0x88, 0x2D, 0x60),
+                });
+                canvas.fill().unwrap();
 
-        nona.begin_path();
-        // nona.rect((100.0, 100.0, 400.0, 300.0));
-        nona.rounded_rect((100.0, 100.0, 400.0, 300.0), 30.0);
-        nona.fill_paint(Gradient::Linear {
-            start: (100, 100).into(),
-            end: (400, 400).into(),
-            start_color: Color::rgb_i(0xAA, 0x6C, 0x39),
-            end_color: Color::rgb_i(0x88, 0x2D, 0x60),
-        });
-        nona.fill().unwrap();
+                canvas.begin_path();
+                canvas.font("roboto");
+                canvas.font_size(40.0);
+                canvas.text_align(Align::TOP | Align::LEFT);
+                canvas.fill_paint(Color::rgb(1.0, 1.0, 1.0));
+                canvas
+                    .text((10, 10), format!("alpha texture font - working!!!"))
+                    .unwrap();
 
-        nona.begin_path();
-        nona.font("roboto");
-        nona.font_size(40.0);
-        nona.text_align(Align::TOP | Align::LEFT);
-        nona.fill_paint(Color::rgb(1.0, 1.0, 1.0));
-        nona.text((10, 10), format!("alpha texture font - working!!!"))
-            .unwrap();
+                // canvas.begin_path();
+                // canvas.rect((100.0, 100.0, 300.0, 300.0));
+                // canvas.fill_paint(nona::Gradient::Linear {
+                //     start: (100, 100).into(),
+                //     end: (400, 400).into(),
+                //     start_color: nona::Color::rgb_i(0xAA, 0x6C, 0x39),
+                //     end_color: nona::Color::rgb_i(0x88, 0x2D, 0x60),
+                // });
+                // canvas.fill().unwrap();
 
-        // nona.begin_path();
-        // nona.rect((100.0, 100.0, 300.0, 300.0));
-        // nona.fill_paint(nona::Gradient::Linear {
-        //     start: (100, 100).into(),
-        //     end: (400, 400).into(),
-        //     start_color: nona::Color::rgb_i(0xAA, 0x6C, 0x39),
-        //     end_color: nona::Color::rgb_i(0x88, 0x2D, 0x60),
-        // });
-        // nona.fill().unwrap();
+                let origin = (150.0, 140.0);
+                canvas.begin_path();
+                canvas.circle(origin, 64.0);
+                canvas.move_to(origin);
+                canvas.line_to((origin.0 + 300.0, origin.1 - 50.0));
+                canvas.stroke_paint(Color::rgba(1.0, 1.0, 0.0, 1.0));
+                canvas.stroke_width(3.0);
+                canvas.stroke().unwrap();
 
-        let origin = (150.0, 140.0);
-        nona.begin_path();
-        nona.circle(origin, 64.0);
-        nona.move_to(origin);
-        nona.line_to((origin.0 + 300.0, origin.1 - 50.0));
-        nona.stroke_paint(Color::rgba(1.0, 1.0, 0.0, 1.0));
-        nona.stroke_width(3.0);
-        nona.stroke().unwrap();
-
-        nona.end_frame().unwrap();
-
-        // nona.save();
-        // nona.global_composite_operation(nona::CompositeOperation::Basic(nona::BasicCompositeOperation::Lighter));
-        // let origin = (150.0, 140.0);
-        // nona.begin_path();
-        // nona.circle(origin, 64.0);
-        // nona.move_to(origin);
-        // nona.line_join(nona::LineJoin::Round);
-        // nona.line_to((origin.0 + 300.0, origin.1 - 50.0));
-        // nona.quad_to((300.0, 100.0), (origin.0 + 500.0, origin.1 + 100.0));
-        // nona.close_path();
-        // nona.fill_paint(nona::Color::rgba(0.2, 0.0, 0.8, 1.0));
-        // nona.fill().unwrap();
-        // nona.stroke_paint(nona::Color::rgba(1.0, 1.0, 0.0, 1.0));
-        // nona.stroke_width(3.0);
-        // nona.stroke().unwrap();
-        // nona.restore();
-
-        // experimental, not yet done
-        // let btn = Button {
-        //     widget: Widget {
-        //         width: 120.0,
-        //         height: 40.0,
-        //         ..Default::default()
-        //     }
-        // };
-
-        // btn.draw(nona).unwrap();
-
-        nona.end_frame().unwrap();
-
-        self.renderer = nona.detach_renderer();
+                canvas.end_frame().unwrap();
+            },
+        );
     }
 }
 
@@ -136,10 +102,6 @@ fn main() {
             high_dpi: true,
             ..Default::default()
         },
-        |ctx| {
-            unsafe { MINI_CONTEXT = Some(ctx) };
-
-            UserData::free(Stage::new())
-        },
+        |mut ctx| UserData::owning(Stage::new(&mut ctx), ctx),
     );
 }

--- a/nonaquad/examples/drawaa.rs
+++ b/nonaquad/examples/drawaa.rs
@@ -12,8 +12,7 @@ struct Stage {
 impl Stage {
     pub fn new(ctx: &mut Context) -> Stage {
         let mut renderer = nvgimpl::Renderer::create(ctx).unwrap();
-        let mut nona =
-            nona::Context::create(&mut nvgimpl::RendererCtx::new(&mut renderer, ctx)).unwrap();
+        let mut nona = nona::Context::create(&mut renderer.with_context(ctx)).unwrap();
 
         // for demo: load font by embedding into binary
         let font_data: &'static [u8] = include_bytes!("Roboto-Bold.ttf");
@@ -32,9 +31,8 @@ impl EventHandler for Stage {
     fn draw(&mut self, ctx: &mut Context) {
         // let ctx = get_context();
 
-        self.nona.attach_renderer(
-            &mut nvgimpl::RendererCtx::new(&mut self.renderer, ctx),
-            |canvas| {
+        self.nona
+            .attach_renderer(&mut self.renderer.with_context(ctx), |canvas| {
                 canvas
                     .begin_frame(Some(Color::rgb_i(128, 128, 255)))
                     .unwrap();
@@ -89,8 +87,7 @@ impl EventHandler for Stage {
                 canvas.stroke().unwrap();
 
                 canvas.end_frame().unwrap();
-            },
-        );
+            });
 
         ctx.commit_frame();
     }

--- a/nonaquad/examples/drawaa.rs
+++ b/nonaquad/examples/drawaa.rs
@@ -91,6 +91,8 @@ impl EventHandler for Stage {
                 canvas.end_frame().unwrap();
             },
         );
+
+        ctx.commit_frame();
     }
 }
 

--- a/nonaquad/src/nvgimpl.rs
+++ b/nonaquad/src/nvgimpl.rs
@@ -992,7 +992,6 @@ impl Renderer {
         }
 
         ctx.end_render_pass();
-        ctx.commit_frame();
 
         // TODO: commented, not needed??
         // glDisableVertexAttribArray(self.shader.loc_vertex);

--- a/nonaquad/src/nvgimpl.rs
+++ b/nonaquad/src/nvgimpl.rs
@@ -91,9 +91,12 @@ pub struct RendererCtx<'a> {
     ctx: &'a mut MiniContext,
 }
 
-impl<'a> RendererCtx<'a> {
-    pub fn new(renderer: &'a mut Renderer, ctx: &'a mut MiniContext) -> Self {
-        RendererCtx { renderer, ctx }
+impl Renderer {
+    pub fn with_context<'a>(&'a mut self, ctx: &'a mut MiniContext) -> RendererCtx<'a> {
+        RendererCtx {
+            renderer: self,
+            ctx,
+        }
     }
 }
 

--- a/nonaquad/src/nvgimpl.rs
+++ b/nonaquad/src/nvgimpl.rs
@@ -71,7 +71,7 @@ struct GLPath {
     stroke_count: usize,
 }
 
-pub struct Renderer<'a> {
+pub struct Renderer {
     // shader: Shader,
     textures: Slab<Texture>, // TODO_REPLACE: bindings.images
     view: Extent,
@@ -84,7 +84,17 @@ pub struct Renderer<'a> {
     vertexes: Vec<Vertex>,
     indices: Vec<u16>,
     uniforms: Vec<shader::Uniforms>,
+}
+
+pub struct RendererCtx<'a> {
+    renderer: &'a mut Renderer,
     ctx: &'a mut MiniContext,
+}
+
+impl<'a> RendererCtx<'a> {
+    pub fn new(renderer: &'a mut Renderer, ctx: &'a mut MiniContext) -> Self {
+        RendererCtx { renderer, ctx }
+    }
 }
 
 mod shader {
@@ -144,7 +154,7 @@ mod shader {
 const MAX_VERTICES: usize = 21845; // u16.max / 3 due to index buffer limitations
 const MAX_INDICES: usize = u16::max_value() as usize;
 
-impl<'a> Renderer<'a> {
+impl Renderer {
     pub fn create(ctx: &mut MiniContext) -> Result<Renderer, NonaError> {
         let shader = Shader::new(ctx, shader::VERTEX, shader::FRAGMENT, shader::meta())
             .map_err(|error| NonaError::Shader(error.to_string()))?;
@@ -189,7 +199,6 @@ impl<'a> Renderer<'a> {
         };
 
         Ok(Renderer {
-            ctx,
             pipeline,
             bindings,
             textures: Default::default(),
@@ -604,21 +613,132 @@ impl IntoTuple4<f32> for Color {
     }
 }
 
-impl renderer::Renderer for Renderer<'_> {
+impl renderer::Renderer for RendererCtx<'_> {
     fn edge_antialias(&self) -> bool {
-        true
+        self.renderer.edge_antialias()
     }
 
     fn view_size(&self) -> (f32, f32) {
-        self.ctx.screen_size()
+        self.renderer.view_size(self.ctx)
     }
 
     fn device_pixel_ratio(&self) -> f32 {
-        self.ctx.dpi_scale()
+        self.renderer.device_pixel_ratio(self.ctx)
     }
 
     fn create_texture(
         &mut self,
+        texture_type: TextureType,
+        width: usize,
+        height: usize,
+        flags: ImageFlags,
+        data: Option<&[u8]>,
+    ) -> Result<ImageId, NonaError> {
+        self.renderer
+            .create_texture(self.ctx, texture_type, width, height, flags, data)
+    }
+
+    fn delete_texture(&mut self, img: ImageId) -> Result<(), NonaError> {
+        self.renderer.delete_texture(img)
+    }
+
+    fn update_texture(
+        &mut self,
+        img: ImageId,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+        data: &[u8],
+    ) -> Result<(), NonaError> {
+        self.renderer
+            .update_texture(self.ctx, img, x, y, width, height, data)
+    }
+
+    fn texture_size(&self, img: ImageId) -> Result<(usize, usize), NonaError> {
+        self.renderer.texture_size(img)
+    }
+
+    fn viewport(&mut self, extent: Extent, device_pixel_ratio: f32) -> Result<(), NonaError> {
+        self.renderer.viewport(extent, device_pixel_ratio)
+    }
+
+    fn clear_screen(&mut self, color: Color) {
+        self.renderer.clear_screen(self.ctx, color)
+    }
+
+    fn flush(&mut self) -> Result<(), NonaError> {
+        self.renderer.flush(self.ctx)
+    }
+
+    fn fill(
+        &mut self,
+        paint: &Paint,
+        composite_operation: CompositeOperationState,
+        scissor: &Scissor,
+        fringe: f32,
+        bounds: Bounds,
+        paths: &[Path],
+    ) -> Result<(), NonaError> {
+        self.renderer.fill(
+            self.ctx,
+            paint,
+            composite_operation,
+            scissor,
+            fringe,
+            bounds,
+            paths,
+        )
+    }
+
+    fn stroke(
+        &mut self,
+        paint: &Paint,
+        composite_operation: CompositeOperationState,
+        scissor: &Scissor,
+        fringe: f32,
+        stroke_width: f32,
+        paths: &[Path],
+    ) -> Result<(), NonaError> {
+        self.renderer.stroke(
+            self.ctx,
+            paint,
+            composite_operation,
+            scissor,
+            fringe,
+            stroke_width,
+            paths,
+        )
+    }
+
+    fn triangles(
+        &mut self,
+        paint: &Paint,
+        composite_operation: CompositeOperationState,
+        scissor: &Scissor,
+        vertexes: &[Vertex],
+    ) -> Result<(), NonaError> {
+        self.renderer
+            .triangles(self.ctx, paint, composite_operation, scissor, vertexes)
+    }
+}
+
+impl Renderer {
+    fn edge_antialias(&self) -> bool {
+        true
+    }
+
+    fn view_size(&self, ctx: &MiniContext) -> (f32, f32) {
+        ctx.screen_size()
+    }
+
+    fn device_pixel_ratio(&self, ctx: &MiniContext) -> f32 {
+        ctx.dpi_scale()
+    }
+
+    fn create_texture(
+        &mut self,
+        ctx: &mut MiniContext,
         texture_type: TextureType,
         width: usize,
         height: usize,
@@ -630,7 +750,7 @@ impl renderer::Renderer for Renderer<'_> {
             TextureType::Alpha => TextureFormat::Alpha,
         };
         let tex: miniquad::Texture = miniquad::Texture::new(
-            self.ctx,
+            ctx,
             TextureAccess::Static,
             data,
             TextureParams {
@@ -664,6 +784,7 @@ impl renderer::Renderer for Renderer<'_> {
 
     fn update_texture(
         &mut self,
+        ctx: &mut MiniContext,
         img: ImageId,
         x: usize,
         y: usize,
@@ -672,14 +793,9 @@ impl renderer::Renderer for Renderer<'_> {
         data: &[u8],
     ) -> Result<(), NonaError> {
         if let Some(texture) = self.textures.get(img) {
-            texture.tex.update_texture_part(
-                self.ctx,
-                x as _,
-                y as _,
-                width as _,
-                height as _,
-                data,
-            );
+            texture
+                .tex
+                .update_texture_part(ctx, x as _, y as _, width as _, height as _, data);
             Ok(())
         } else {
             Err(NonaError::Texture(format!("texture '{}' not found", img)))
@@ -699,12 +815,11 @@ impl renderer::Renderer for Renderer<'_> {
         Ok(())
     }
 
-    fn clear_screen(&mut self, color: Color) {
-        self.ctx
-            .clear(Some((color.r, color.g, color.b, color.a)), None, None);
+    fn clear_screen(&mut self, ctx: &mut MiniContext, color: Color) {
+        ctx.clear(Some((color.r, color.g, color.b, color.a)), None, None);
     }
 
-    fn flush(&mut self) -> Result<(), NonaError> {
+    fn flush(&mut self, ctx: &mut MiniContext) -> Result<(), NonaError> {
         if self.calls.is_empty() {
             self.vertexes.clear();
             self.paths.clear();
@@ -713,16 +828,16 @@ impl renderer::Renderer for Renderer<'_> {
 
             return Ok(());
         }
-        self.ctx.begin_default_pass(PassAction::Nothing);
+        ctx.begin_default_pass(PassAction::Nothing);
 
         // glUseProgram(self.shader.prog); DONE
-        self.ctx.apply_pipeline(&self.pipeline);
-        self.ctx.apply_bindings(&self.bindings); // NEEDED - must be called before vertex buffer update; TODO_BUG: can be optimized in miniquad; we only need to update index buffer in most cases, see do_convex_fill()
-        self.bindings.vertex_buffers[0].update(self.ctx, &self.vertexes); // TODO: miniquad BUG? this line must show after apply_bindings otherwise no display of vertex buffer can happen
+        ctx.apply_pipeline(&self.pipeline);
+        ctx.apply_bindings(&self.bindings); // NEEDED - must be called before vertex buffer update; TODO_BUG: can be optimized in miniquad; we only need to update index buffer in most cases, see do_convex_fill()
+        self.bindings.vertex_buffers[0].update(ctx, &self.vertexes); // TODO: miniquad BUG? this line must show after apply_bindings otherwise no display of vertex buffer can happen
 
         // glEnable(GL_CULL_FACE);
         // glCullFace(GL_BACK);
-        self.ctx.set_cull_face(CullFace::Back);
+        ctx.set_cull_face(CullFace::Back);
         // glFrontFace(GL_CCW); // DONE front_face_order
 
         // glEnable(GL_BLEND); // TODO_BELOW
@@ -778,12 +893,12 @@ impl renderer::Renderer for Renderer<'_> {
             let call: &Call = call; // added to make rust-analyzer type inferrence work. See https://github.com/rust-analyzer/rust-analyzer/issues/4160
             let blend = &call.blend_func;
 
-            self.ctx.set_blend(Some(blend.color), Some(blend.alpha));
+            ctx.set_blend(Some(blend.color), Some(blend.alpha));
 
             // {
             //     // TODO: set image in a better way!!!
             //     self.bindings.images = vec![];
-            //     self.ctx.apply_bindings(&self.bindings);
+            //     ctx.apply_bindings(&self.bindings);
             // }
 
             // glBlendFuncSeparate( // TODO: DELETE once tested
@@ -796,14 +911,14 @@ impl renderer::Renderer for Renderer<'_> {
             // println!("Call {:?}", call.call_type); // DEBUG
 
             // update view size for the uniforms that may be in use
-            self.uniforms[call.uniform_offset].view_size = self.ctx.screen_size();
+            self.uniforms[call.uniform_offset].view_size = ctx.screen_size();
             if self.uniforms.len() > call.uniform_offset + 1 {
-                self.uniforms[call.uniform_offset + 1].view_size = self.ctx.screen_size();
+                self.uniforms[call.uniform_offset + 1].view_size = ctx.screen_size();
             }
             let uniforms: &shader::Uniforms = &self.uniforms[call.uniform_offset];
             if let Some(image_index) = call.image {
                 self.bindings.images[0] = self.textures[image_index].tex;
-                // self.ctx.apply_bindings(&self.bindings); // not needed - will be called in the call_type handlers below
+                // ctx.apply_bindings(&self.bindings); // not needed - will be called in the call_type handlers below
             }
 
             match call.call_type {
@@ -814,7 +929,7 @@ impl renderer::Renderer for Renderer<'_> {
                     let uniforms_next: &shader::Uniforms = &self.uniforms[call.uniform_offset + 1];
 
                     Self::do_fill(
-                        self.ctx,
+                        ctx,
                         call,
                         paths,
                         &self.bindings,
@@ -835,20 +950,20 @@ impl renderer::Renderer for Renderer<'_> {
                     // ];
                     // let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
 
-                    // self.bindings.vertex_buffers[0].update(self.ctx, &vertices);
+                    // self.bindings.vertex_buffers[0].update(ctx, &vertices);
                     // self.bindings
                     //     .index_buffer
-                    //     .update(self.ctx, &indices);
+                    //     .update(ctx, &indices);
 
-                    // self.ctx.apply_bindings(&self.bindings);
-                    // Self::set_uniforms(self.ctx, uniforms, call.image);
+                    // ctx.apply_bindings(&self.bindings);
+                    // Self::set_uniforms(ctx, uniforms, call.image);
 
-                    // self.ctx.draw(0, 3, 1);
+                    // ctx.draw(0, 3, 1);
 
                     let paths = &self.paths[call.path_offset..call.path_offset + call.path_count];
 
                     Self::do_convex_fill(
-                        self.ctx,
+                        ctx,
                         call,
                         paths,
                         &self.bindings,
@@ -861,7 +976,7 @@ impl renderer::Renderer for Renderer<'_> {
                     let uniforms_next: &shader::Uniforms = &self.uniforms[call.uniform_offset + 1];
 
                     Self::do_stroke(
-                        self.ctx,
+                        ctx,
                         call,
                         paths,
                         &self.bindings,
@@ -871,13 +986,13 @@ impl renderer::Renderer for Renderer<'_> {
                     );
                 }
                 CallType::Triangles => {
-                    Self::do_triangles(self.ctx, call, &self.bindings, &mut self.indices, uniforms);
+                    Self::do_triangles(ctx, call, &self.bindings, &mut self.indices, uniforms);
                 }
             }
         }
 
-        self.ctx.end_render_pass();
-        self.ctx.commit_frame();
+        ctx.end_render_pass();
+        ctx.commit_frame();
 
         // TODO: commented, not needed??
         // glDisableVertexAttribArray(self.shader.loc_vertex);
@@ -885,7 +1000,7 @@ impl renderer::Renderer for Renderer<'_> {
         // glBindVertexArray(0);
 
         // glDisable(GL_CULL_FACE);
-        self.ctx.set_cull_face(CullFace::Nothing);
+        ctx.set_cull_face(CullFace::Nothing);
 
         // glBindBuffer(GL_ARRAY_BUFFER, 0);
         // glUseProgram(0);
@@ -900,6 +1015,7 @@ impl renderer::Renderer for Renderer<'_> {
 
     fn fill(
         &mut self,
+        ctx: &mut MiniContext,
         paint: &Paint,
         composite_operation: CompositeOperationState,
         scissor: &Scissor,
@@ -925,7 +1041,7 @@ impl renderer::Renderer for Renderer<'_> {
 
         // if GPU overflow
         if new_vertex_count >= MAX_VERTICES {
-            self.flush()?;
+            self.flush(ctx)?;
         }
 
         let mut call = Call {
@@ -996,6 +1112,7 @@ impl renderer::Renderer for Renderer<'_> {
 
     fn stroke(
         &mut self,
+        ctx: &mut MiniContext,
         paint: &Paint,
         composite_operation: CompositeOperationState,
         scissor: &Scissor,
@@ -1010,7 +1127,7 @@ impl renderer::Renderer for Renderer<'_> {
 
         // if GPU overflow
         if new_vertex_count >= MAX_VERTICES {
-            self.flush()?;
+            self.flush(ctx)?;
         }
 
         let mut call = Call {
@@ -1059,6 +1176,7 @@ impl renderer::Renderer for Renderer<'_> {
 
     fn triangles(
         &mut self,
+        ctx: &mut MiniContext,
         paint: &Paint,
         composite_operation: CompositeOperationState,
         scissor: &Scissor,
@@ -1069,7 +1187,7 @@ impl renderer::Renderer for Renderer<'_> {
 
         // if GPU overflow
         if new_vertex_count >= MAX_VERTICES {
-            self.flush()?;
+            self.flush(ctx)?;
         }
 
         let call = Call {


### PR DESCRIPTION
This change removes the ownership of `miniquad::Context` by nonaquad's renderer.
This allows the integration of `nona` and `nonaquad` in other application as a canvas painting layer.

See modified `drawaa` example for the largest API change.